### PR TITLE
Added license to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 # python -m twine upload  dist/*
 
 setuptools.setup(
+    license="MIT",
     name="streamlit-agraph",
     version="0.0.42",
     author="Christian Klose",


### PR DESCRIPTION
Minor thing, I was unable to use this at work as there was no license defined - I assume they are looking at the asset on PyPi which gets it from the setup.py file.