### PR TITLE
Issuefix/triple store error

### DIFF
--- a/streamlit_agraph/node.py
+++ b/streamlit_agraph/node.py
@@ -22,3 +22,10 @@ class Node:
 
   def to_dict(self):
     return self.__dict__
+
+  def __eq__(self, other) -> bool:
+    return (isinstance(other, self.__class__) and
+            getattr(other, 'id', None) == self.id)
+
+  def __hash__(self) -> int:
+    return hash(self.id)

--- a/streamlit_agraph/triplestore.py
+++ b/streamlit_agraph/triplestore.py
@@ -14,6 +14,9 @@ class TripleStore:
     nodeA = Node(id=node1, image=image)
     nodeB = Node(id=node2)
     edge = Edge(source=nodeA.id, target=nodeB.id, title=link)  # linkValue=link
+    self.add_triple_base(nodeA, edge, nodeB)
+  
+  def add_triple_base(self, nodeA: Node, edge: Edge, nodeB: Node):
     triple = Triple(nodeA, edge, nodeB)
     self.nodes_set.update([nodeA, nodeB])
     self.edges_set.add(edge)


### PR DESCRIPTION
Got the same [issue](https://github.com/ChrisDelClea/streamlit-agraph/issues/32)
This happens because the store is creating the set of nodes, and set uses hash.

Added the `__eq__` and `__hash__` for the `Node` based on ID of the Node.
Added one method under `TripleStore` to capture the Triples with objects of `Node` and `Edge`.

Also, it's looking for `streamlit_agraph/frontend/build/bootstrap.min.css.map` which is not there when installed the package from pip, not sure if it's expected to be there or if it's a configuration issue at my end.
Trying resolve that, please let me know if it's a known issue.