### PR TITLE
Return edge id when selecting only edge

### DIFF
--- a/streamlit_agraph/frontend/src/StreamlitVisGraph.tsx
+++ b/streamlit_agraph/frontend/src/StreamlitVisGraph.tsx
@@ -16,9 +16,18 @@ function StreamlitVisGraph() {
 
   const events: GraphEvents = {
     selectNode: (event) => {
-      Streamlit.setComponentValue(event.nodes[0]);
-    }
-    ,
+      // Always prioritize node selection when a node is selected, 
+      // regardless of whether edges are also selected
+      if (event.nodes.length > 0) {
+        Streamlit.setComponentValue(event.nodes[0]);
+      }
+    },
+    selectEdge: (event) => {
+      // Only handle edge selection when no nodes are selected
+      if (event.edges.length > 0 && event.nodes.length === 0) {
+        Streamlit.setComponentValue(event.edges[0]);
+      }
+    },
     doubleClick: (event) => {
       const lookupNode = lookupNodeId(event.nodes[0], graph.nodes);
       if (lookupNode && lookupNode.link) {


### PR DESCRIPTION
First, thank you for this wonderful open source project! It has really helped me in my project. 

This PR should solve [this issue](https://github.com/ChrisDelClea/streamlit-agraph/issues/70). 

It is maybe opinionated in the sense that you only get back the edge id as the component value if it is the only thing selected, since I noticed clicking a node will select edges as well, and I didn't want to change existing functionality.  

You could also modify the TypeScript here pretty easily to allow for other events to be handled (ex. hold, release) or change the component value to pass more values back through `agraph` other than simply the node id (or edge id!) - that may break people's projects relying on simply the id coming back instead of a dictionary or list of data, but might be helpful. I would be happy to help contribute changes, this is an awesome project. 